### PR TITLE
Add CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      # Required when project is checked out on Windows to prevent crash
+      # Ensure Maven wrapper is executable (Git may not preserve permissions)
       - name: Make mvnw executable
         run: chmod +x mvnw
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,21 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: team4you
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       # Checks out the repository code
       - uses: actions/checkout@v6.0.2
@@ -29,3 +44,8 @@ jobs:
       # Builds the project and runs all tests
       - name: Build and test
         run: ./mvnw verify
+        env:
+          DB_URL: jdbc:postgresql://localhost:5432/team4you
+          DB_USERNAME: postgres
+          DB_PASSWORD: postgres
+          SPRING_DOCKER_COMPOSE_ENABLED: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI Pipeline
+
+# Triggers on push and pull requests
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks out the repository code
+      - uses: actions/checkout@v6.0.2
+
+      # Sets up Java25 and caches Maven dependencies
+      - uses: actions/setup-java@v5.2.0
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: maven
+
+      # Required when project is checked out on Windows to prevent crash
+      - name: Make mvnw executable
+        run: chmod +x mvnw
+
+      # Builds the project and runs all tests
+      - name: Build and test
+        run: ./mvnw verify


### PR DESCRIPTION
Sets up Github actions with CI pipeline that automatically builds and tests the project on push and pull requests.

- Java 25
- Maven build with ./mvnw verify
- chmod +x mvnw included to prevent permission denied error
- Tested locally with act on Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated CI pipeline triggered on pushes and pull requests to main and develop.
  * Runs Java 25 builds and full Maven verification with dependency caching.
  * Launches a PostgreSQL 16 service for integration tests with health checks and connection environment variables.
  * Ensures build tooling is executable before running verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->