### PR TITLE
fix: change cancelBooking id type from String to Long

### DIFF
--- a/src/main/java/backendlab/team4you/booking/BookingController.java
+++ b/src/main/java/backendlab/team4you/booking/BookingController.java
@@ -70,7 +70,7 @@ public class BookingController {
 
     @PostMapping("/booking/cancel")
     public String cancelBooking(
-            @RequestParam String id,
+            @RequestParam Long id,
             Model model
     ) {
 

--- a/src/main/java/backendlab/team4you/booking/BookingRepository.java
+++ b/src/main/java/backendlab/team4you/booking/BookingRepository.java
@@ -1,14 +1,9 @@
 package backendlab.team4you.booking;
 
-import backendlab.team4you.user.UserEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface BookingRepository extends JpaRepository<BookingEntity, Long> {
-    Optional<BookingEntity> findById(String id);
-
     Page<BookingEntity> findAll(Pageable pageable);
 }

--- a/src/main/java/backendlab/team4you/booking/BookingService.java
+++ b/src/main/java/backendlab/team4you/booking/BookingService.java
@@ -15,7 +15,7 @@ public class BookingService {
 
 
     @Transactional
-    public void cancelBooking(String id) {
+    public void cancelBooking(Long id) {
         BookingEntity booking = bookingRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Booking not found"));
 

--- a/src/test/java/backendlab/team4you/booking/BookingServiceTest.java
+++ b/src/test/java/backendlab/team4you/booking/BookingServiceTest.java
@@ -77,4 +77,20 @@ class BookingServiceTest {
 
         assertThrows(RuntimeException.class, () -> bookingService.delete(99L));
     }
+
+    @Test
+    void cancelBooking_shouldSetStatusToCancelled() {
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(booking));
+
+        bookingService.cancelBooking(1L);
+
+        assertEquals(BookingEnum.CANCELLED, booking.getStatus());
+    }
+
+    @Test
+    void cancelBooking_shouldThrowException_whenBookingNotFound() {
+        when(bookingRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(RuntimeException.class, () -> bookingService.cancelBooking(99L));
+    }
 }


### PR DESCRIPTION
Ändrade cancelBooking från string till Long i BookingService, BookingController och BookingRepository för att förhindra krasch. 

Gjorde också ett till test för cancelBooking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for the booking cancellation feature to ensure reliability and proper error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->