### PR TITLE
Fix: bucket now starts automaticly with docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,6 +26,5 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-
 volumes:
   postgres_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,10 +17,12 @@ services:
     ports:
       - "4566:4566"
     environment:
-      - SERVICES=s3
-      - DEFAULT_REGION=eu-north-1
+      SERVICES: s3
+      DEFAULT_REGION: eu-north-1
+      AWS_BUCKET_NAME: ${AWS_BUCKET_NAME:-team4you-files}
     volumes:
       - ./init-localstack.sh:/etc/localstack/init/ready.d/init-localstack.sh
+      - localstack_data:/var/lib/localstack
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
       interval: 10s
@@ -29,3 +31,4 @@ services:
 
 volumes:
   postgres_data:
+  localstack_data:

--- a/init-localstack.sh
+++ b/init-localstack.sh
@@ -4,7 +4,12 @@ set -euo pipefail
 bucket="${AWS_BUCKET_NAME:-team4you-files}"
 echo "checking/creating s3 bucket: $bucket"
 
-awslocal s3api head-bucket --bucket "$bucket" 2>/dev/null || awslocal s3 mb "s3://$bucket"
+if awslocal s3api head-bucket --bucket "$bucket" 2>/dev/null; then
+  echo "bucket already exists: $bucket"
+else
+  echo "creating bucket: $bucket"
+  awslocal s3 mb "s3://$bucket"
+fi
 
 echo "available buckets:"
 awslocal s3 ls

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,11 @@
             <version>0.30.2.RELEASE</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/backendlab/team4you/s3/S3BucketInitializer.java
+++ b/src/main/java/backendlab/team4you/s3/S3BucketInitializer.java
@@ -4,14 +4,17 @@ import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Profile;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 
 @Component
-@Profile("dev")
+@ConditionalOnProperty(
+        name = "aws.create-bucket-if-missing",
+        havingValue = "true"
+)
 public class S3BucketInitializer {
 
     private static final Logger log = LoggerFactory.getLogger(S3BucketInitializer.class);

--- a/src/main/java/backendlab/team4you/s3/S3BucketInitializer.java
+++ b/src/main/java/backendlab/team4you/s3/S3BucketInitializer.java
@@ -1,0 +1,40 @@
+package backendlab.team4you.s3;
+
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+
+@Component
+@Profile("dev")
+public class S3BucketInitializer {
+
+    private static final Logger log = LoggerFactory.getLogger(S3BucketInitializer.class);
+
+    private final S3Client s3Client;
+
+    @Value("${aws.bucket-name}")
+    private String bucketName;
+
+    public S3BucketInitializer(S3Client s3Client) {
+        this.s3Client = s3Client;
+    }
+
+    @PostConstruct
+    public void ensureBucketExists() {
+        try {
+            s3Client.headBucket(builder -> builder.bucket(bucketName));
+            log.info("S3 bucket already exists: {}", bucketName);
+        } catch (NoSuchBucketException exception) {
+            log.info("Creating local S3 bucket: {}", bucketName);
+            s3Client.createBucket(CreateBucketRequest.builder()
+                    .bucket(bucketName)
+                    .build());
+        }
+    }
+}

--- a/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,9 @@
+{
+  "properties": [
+    {
+      "name": "aws.create-bucket-if-missing",
+      "type": "java.lang.Boolean",
+      "description": "Whether to create S3 bucket automatically if missing."
+    }
+  ]
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,1 @@
+aws.create-bucket-if-missing=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,4 +20,4 @@ aws.secret-key=${AWS_SECRET_KEY}
 aws.region=${AWS_REGION}
 aws.bucket-name=${AWS_BUCKET_NAME}
 aws.endpoint-url=${AWS_ENDPOINT_URL}
-aws.create-bucket-if-missing=true
+aws.create-bucket-if-missing=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,4 @@ aws.secret-key=${AWS_SECRET_KEY}
 aws.region=${AWS_REGION}
 aws.bucket-name=${AWS_BUCKET_NAME}
 aws.endpoint-url=${AWS_ENDPOINT_URL}
+aws.create-bucket-if-missing=true


### PR DESCRIPTION
resolves #51 

bucket is now created automaticly on stratup with docker-compose

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured persistent storage for the LocalStack development environment to preserve data across restarts
  * Added configurable bucket name for local testing via environment variable with a sensible default

* **New Features**
  * Improved S3 initialization to explicitly check for and create the required bucket at startup, with clearer status messages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->